### PR TITLE
Add serializer customization to plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,12 @@ module.exports.options = {
     watch: {
         default: false,
         runtimeParameter: 'watch'
+    },
+    serializers: {
+        marks: {
+            annotations: [],
+        },
+        types: {},
     }
 };
 

--- a/lib/sanity-util.js
+++ b/lib/sanity-util.js
@@ -17,13 +17,19 @@ function convertBlockToHTML({ blocks, cache, entriesById, options, visitedIds })
         return blockToHTML.h('img', { src: normalizedImage.url });
     };
 
+    const allSerializers = {
+      types: {
+          ...options.serializers.types,
+          image: imageSerializer
+      },
+      marks: {
+          ...options.serializers.marks
+      }
+    }
+
     return blockToHTML({
         blocks,
-        serializers: {
-            types: {
-                image: imageSerializer
-            }
-        }
+        serializers: allSerializers,
     });
 }
 


### PR DESCRIPTION
Hi! I'm opening a PR to add custom serializers, as per the need in issue #17 .

This PR adds serializer options for `marks` and `types` to the `option` exports in `index.js` and adds the ability to read those serializers in addition to the image serializer in `sanity-util.js`.

Let me know if you have any questions, and thanks for a great tool!